### PR TITLE
Fix workflow field to allow null values

### DIFF
--- a/oarepo_workflows/model/presets/services/records/parent_record_schema.py
+++ b/oarepo_workflows/model/presets/services/records/parent_record_schema.py
@@ -42,6 +42,6 @@ class WorkflowsParentRecordSchemaPreset(Preset):
         dependencies: dict[str, Any],
     ) -> Generator[Customization]:
         class WorkflowSchemaMixin:
-            workflow = ma.fields.String()
+            workflow = ma.fields.String(allow_none=True)
 
         yield PrependMixin("ParentRecordSchema", WorkflowSchemaMixin)


### PR DESCRIPTION
## Summary
- Added `allow_none=True` to workflow field in `WorkflowsParentRecordSchemaPreset`
- Fixes validation error `{'parent': {'workflow': 'Field may not be null.'}}` when workflow is null


I am not sure if this is a valid solution. Please take a look.
## Test plan
- [ ] Verify records with null workflow values can be loaded without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)