### PR TITLE
breaking: renamed composite generators to better names

### DIFF
--- a/oarepo_workflows/requests/events.py
+++ b/oarepo_workflows/requests/events.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import dataclasses
 from functools import cached_property
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, NoReturn, cast
 
 from oarepo_workflows.errors import EventTypeNotInWorkflowError
 from oarepo_workflows.requests.generators.multiple_entities import (
@@ -39,7 +39,7 @@ class WorkflowEvent:
     @cached_property
     def submitter_generator(self) -> Generator:
         """Return the requesters as a single requester generator."""
-        return MultipleEntitiesGenerator(self.submitters)
+        return cast("Generator", MultipleEntitiesGenerator(self.submitters))
 
 
 class WorkflowEvents(dict[str, WorkflowEvent]):

--- a/oarepo_workflows/requests/generators/multiple_entities.py
+++ b/oarepo_workflows/requests/generators/multiple_entities.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING, Any, override
 
+from invenio_records_permissions.generators import CompositeGenerator
+
 from ...resolvers.multiple_entities import MultipleEntitiesEntity
-from ...services.permissions.generators import AggregateGenerator
 from .recipient_generator import RecipientGeneratorMixin
 
 if TYPE_CHECKING:
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 
 @dataclasses.dataclass
-class MultipleEntitiesGenerator(RecipientGeneratorMixin, AggregateGenerator):
+class MultipleEntitiesGenerator(RecipientGeneratorMixin, CompositeGenerator):
     """A generator that combines multiple generators with 'or' operation."""
 
     generators: Sequence[InvenioGenerator]

--- a/oarepo_workflows/requests/requests.py
+++ b/oarepo_workflows/requests/requests.py
@@ -69,7 +69,7 @@ class WorkflowRequest:
     @cached_property
     def requester_generator(self) -> Generator:
         """Return the requesters as a single requester generator."""
-        return MultipleEntitiesGenerator(self.requesters)
+        return cast("Generator", MultipleEntitiesGenerator(self.requesters))
 
     def recipient_entity_reference(self, **context: Any) -> Mapping[str, str] | None:
         """Return the reference receiver of the workflow request with the given context.

--- a/oarepo_workflows/services/permissions/composite.py
+++ b/oarepo_workflows/services/permissions/composite.py
@@ -37,7 +37,7 @@ class HashableList(list):
     Identity-based semantics (``__hash__``, ``__eq__``, ``__ne__``) are
     intentional: two ``HashableList`` instances that hold the same generators
     are still treated as distinct objects.  This ensures that every call to
-    ``CompositeAndGenerator.needs()`` produces a unique ``Need`` in the
+    ``RequireAll.needs()`` produces a unique ``Need`` in the
     policy's ``explicit_needs`` set, regardless of whether the generator list
     contents happen to compare equal.
 
@@ -60,12 +60,12 @@ class HashableList(list):
         return self is not other
 
 
-class CompositeAndGenerator(Generator):
+class RequireAll(Generator):
     """A generator that requires **all** of its inner generators to be satisfied.
 
     Standard invenio generators are combined with **OR** semantics inside a
     permission policy: granting access as soon as *any* generator produces a
-    need that matches the identity.  ``CompositeAndGenerator`` provides **AND**
+    need that matches the identity.  ``RequireAll`` provides **AND**
     semantics: every inner generator must independently produce at least one
     need that matches the identity before access is granted.
 
@@ -73,9 +73,9 @@ class CompositeAndGenerator(Generator):
     ``excludes`` API, this generator encodes its inner generator list as a
     single opaque ``Need(method="composite", value=HashableList([...]))``.
     The actual AND evaluation is then carried out by
-    :class:`CompositePermissionPolicyMixin` inside its ``allows()`` override.
+    :class:`BooleanPermissionPolicyMixin` inside its ``allows()`` override.
 
-    Multiple ``CompositeAndGenerator`` instances in the same ``can_*`` list are
+    Multiple ``RequireAll`` instances in the same ``can_*`` list are
     evaluated with **OR** semantics between them (the standard invenio
     behaviour): access is granted if *any* of those composites is fully
     satisfied.
@@ -83,12 +83,12 @@ class CompositeAndGenerator(Generator):
     Example usage::
 
         class MyPolicy(
-            CompositePermissionPolicyMixin,
+            BooleanPermissionPolicyMixin,
             RecordPermissionPolicy,
         ):
             # User must be owner *and* hold the "reviewer" role.
             can_review = [
-                CompositeAndGenerator(
+                RequireAll(
                     RecordOwners(),
                     ReviewerRole(),
                 ),
@@ -96,9 +96,8 @@ class CompositeAndGenerator(Generator):
 
     .. important::
         The permission policy that hosts this generator **must** inherit from
-        :class:`CompositePermissionPolicyMixin` and must inject ``policy=self``
-        into the ``over`` context (see that class for details).  Failing to do
-        so will cause ``needs()`` to raise ``ValueError`` or ``TypeError``.
+        :class:`BooleanPermissionPolicyMixin`.  Failing to do so will cause
+        ``needs()`` to raise ``TypeError``.
     """
 
     def __init__(self, *generators: Generator):
@@ -108,7 +107,7 @@ class CompositeAndGenerator(Generator):
             access to be granted.  Providing zero generators results in a
             composite that is vacuously always satisfied (the ``for`` loop
             finishes without a ``break``, triggering the ``else`` branch in
-            ``CompositePermissionPolicyMixin.allows``).
+            ``BooleanPermissionPolicyMixin.allows``).
         """
         self.generators = generators
 
@@ -119,7 +118,7 @@ class CompositeAndGenerator(Generator):
         invenio combines with OR), so this method does *not* return the inner
         generators' needs directly.  Instead it encodes the entire generator
         list as a single ``Need(method="composite", value=HashableList([...]))``
-        sentinel.  :class:`CompositePermissionPolicyMixin` recognises that
+        sentinel.  :class:`BooleanPermissionPolicyMixin` recognises that
         sentinel in ``allows()`` and carries out the actual AND check there.
 
         A fresh :class:`HashableList` is created on every call so that each
@@ -128,18 +127,18 @@ class CompositeAndGenerator(Generator):
         policy instance, as invenio accumulates needs into a set.
 
         :param context: The keyword arguments forwarded by the policy's
-            ``needs`` property (i.e. ``self.over``).  Must contain a ``policy``
-            key whose value is an instance of
-            :class:`CompositePermissionPolicyMixin`.
-        :raises ValueError: If ``context`` contains no ``"policy"`` key.
-        :raises TypeError: If the ``"policy"`` value is not an instance of
-            :class:`CompositePermissionPolicyMixin`.
+            ``needs`` property (i.e. ``self.over``).  Must contain a
+            ``"permission_policy"`` key whose value is an instance of
+            :class:`BooleanPermissionPolicyMixin`.
+        :raises ValueError: If ``context`` contains no ``"permission_policy"`` key.
+        :raises TypeError: If the ``"permission_policy"`` value is not an instance of
+            :class:`BooleanPermissionPolicyMixin`.
         :returns: A one-element list containing the composite ``Need``.
         """
-        if "policy" not in context:
+        if "permission_policy" not in context:
             raise ValueError("Permission policy class is not set up in context")
-        if not isinstance(context["policy"], CompositePermissionPolicyMixin):
-            raise TypeError("Permission policy class is not a CompositePermissionPolicyMixin")
+        if not isinstance(context["permission_policy"], BooleanPermissionPolicyMixin):
+            raise TypeError("Permission policy class is not a BooleanPermissionPolicyMixin")
         # Wrap the generator tuple in a HashableList so the resulting Need is
         # hashable and can live inside the frozenset returned by
         # BasePermissionPolicy.needs.
@@ -147,19 +146,19 @@ class CompositeAndGenerator(Generator):
 
     def __repr__(self) -> str:
         """Return a developer-friendly representation of this generator."""
-        return f"CompositeAndGenerator({', '.join(repr(generator) for generator in self.generators)})"
+        return f"RequireAll({', '.join(repr(generator) for generator in self.generators)})"
 
     def __str__(self) -> str:
         """Return the string form of this generator (same as ``repr``)."""
         return repr(self)
 
 
-class CompositePermissionPolicyMixin(RecordPermissionPolicyTypeCheckingBase):
-    """Permission-policy mixin that evaluates :class:`CompositeAndGenerator` needs.
+class BooleanPermissionPolicyMixin(RecordPermissionPolicyTypeCheckingBase):
+    """Permission-policy mixin that evaluates :class:`RequireAll` needs.
 
     Invenio's built-in ``Permission.allows()`` collects all needs into a flat
     set and grants access if the identity matches *any* of them (OR semantics).
-    Composite needs — produced by :class:`CompositeAndGenerator` — require AND
+    Composite needs — produced by :class:`RequireAll` — require AND
     semantics that cannot be expressed in that flat model, so this mixin
     overrides ``allows()`` with a two-phase check:
 
@@ -185,34 +184,17 @@ class CompositePermissionPolicyMixin(RecordPermissionPolicyTypeCheckingBase):
        If no composite is satisfied and no exclude was triggered, return
        ``False``.
 
-    **OR semantics between composites**: multiple ``CompositeAndGenerator``
+    **OR semantics between composites**: multiple ``RequireAll``
     instances in the same ``can_*`` list each produce their own composite
     ``Need``.  The loop tries all of them; the first fully-satisfied one grants
     access.
-
-    **Setup requirement**: The policy's ``over`` context dict must contain a
-    ``"policy"`` key pointing to the policy instance itself *before* ``needs``
-    is first accessed.  Concrete subclasses should set this in ``__init__``::
-
-        class MyPolicy(
-            CompositePermissionPolicyMixin,
-            RecordPermissionPolicy,
-        ):
-            def __init__(self, action, **over):
-                super().__init__(action, **over)
-                self.over["policy"] = self
-
-    This is already handled by both :class:`~oarepo_workflows.services.permissions
-    .workflow_permissions.DefaultWorkflowPermissions` and
-    :class:`~oarepo_workflows.services.permissions.record_permission_policy
-    .WorkflowRecordPermissionPolicyMixin`.
     """
 
     def allows(self, identity: Identity) -> bool:
         """Return whether *identity* is permitted by this policy.
 
         Extends ``Permission.allows`` with AND-composite evaluation for any
-        :class:`CompositeAndGenerator` generators present in the active
+        :class:`RequireAll` generators present in the active
         ``can_*`` list.
 
         :param identity: The Flask-Principal identity to check.

--- a/oarepo_workflows/services/permissions/generators.py
+++ b/oarepo_workflows/services/permissions/generators.py
@@ -11,15 +11,16 @@ from __future__ import annotations
 
 import logging
 import operator
+import warnings
 from functools import reduce
 from typing import TYPE_CHECKING, Any, override
 
 from flask import current_app
 from flask_principal import Identity, RoleNeed
 from invenio_access import ActionNeed
+from invenio_records_permissions.generators import SameAs as InvenioSameAs
 from invenio_search.engine import dsl
 from oarepo_runtime.services.generators import (
-    AggregateGenerator,
     ConditionalGenerator,
     Generator,
 )
@@ -32,7 +33,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
 
     from flask_principal import Need
-    from invenio_records_permissions import RecordPermissionPolicy
     from invenio_records_permissions.generators import Generator as InvenioGenerator
     from invenio_records_resources.records import Record
     from invenio_requests.customizations.request_types import RequestType
@@ -297,7 +297,7 @@ class IfInState(RecipientGeneratorMixin, ConditionalGenerator):
         return repr(self)
 
 
-class SameAs(AggregateGenerator):
+class SameAs(InvenioSameAs):
     """Generator that delegates the permissions to another action.
 
     Example:
@@ -314,54 +314,15 @@ class SameAs(AggregateGenerator):
     """
 
     def __init__(self, permission_name: str) -> None:
-        """Initialize the generator.
-
-        :param permission_name: Name of the permission to delegate to. In most cases,
-        it will look like "can_<action>". A property with this name must exist on the policy
-        and its value must be a list of generators.
-        """
-        self.delegated_permission_name = permission_name
-
-    @override
-    def _generators(self, policy: RecordPermissionPolicy, **context: Any) -> Sequence[Generator]:  # type: ignore[override]
-        """Get the generators from the policy."""
-        return getattr(policy, self.delegated_permission_name)  # type: ignore[no-any-return]
-
-    @override
-    def needs(self, policy: RecordPermissionPolicy | None = None, **context: Any) -> Sequence[Need]:  # type: ignore[reportIncompatibleMethodOverride]
-        """Get the needs from the policy."""
-        if policy is None:
-            raise ValueError(
-                f"SameAs: Policy must be passed to the generator. Got the following context: {context.keys()}"
-            )
-        # the type: ignore should not be necessary here
-        return super().needs(**context | {"policy": policy})  # type: ignore[no-any-return]
-
-    @override
-    def excludes(self, policy: RecordPermissionPolicy | None = None, **context: Any) -> Sequence[Need]:  # type: ignore[reportIncompatibleMethodOverride]
-        """Get the excludes from the policy."""
-        if policy is None:
-            raise ValueError(
-                f"SameAs: Policy must be passed to the generator. Got the following context: {context.keys()}"
-            )
-        return super().excludes(**context | {"policy": policy})  # type: ignore[no-any-return]
-
-    @override
-    def query_filter(self, policy: RecordPermissionPolicy | None = None, **context: Any) -> dsl.query.Query:  # type: ignore[reportIncompatibleMethodOverride]
-        """Get the query_filter from the policy."""
-        if policy is None:
-            raise ValueError(
-                f"SameAs: Policy must be passed to the generator. Got the following context: {context.keys()}"
-            )
-        return super().query_filter(**context | {"policy": policy})
-
-    def __repr__(self) -> str:
-        """Return representation of the generator."""
-        return f"SameAs({self.delegated_permission_name})"
-
-    def __str__(self) -> str:
-        """Return String representation of the generator."""
-        return repr(self)
+        """Emit a deprecation warning and delegate to Invenio's SameAs."""
+        warnings.warn(
+            "oarepo_workflows SameAs has been moved to invenio_records_permissions.generators.SameAs"
+            " and will be removed in a future version. "
+            "Use invenio_records_permissions.generators.SameAs directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(permission_name)
 
 
 class UserWithRole(RecipientGeneratorMixin, Generator):

--- a/oarepo_workflows/services/permissions/record_permission_policy.py
+++ b/oarepo_workflows/services/permissions/record_permission_policy.py
@@ -9,17 +9,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from invenio_records_permissions.generators import (
     AnyUser,
+    SameAs,
     SystemProcess,
 )
 
 from .generators import (
     FromRecordWorkflow,
     InAnyWorkflow,
-    SameAs,
     query_filters_from_all_workflows,
 )
 
@@ -37,17 +37,6 @@ class WorkflowRecordPermissionPolicyMixin(InvenioRecordPermissionPolicy):
 
     Do not use this class in Workflow constructor.
     """
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        """Store a permission policy in over so that SameAs can use it.
-
-        Note: after 2.1.0 release of invenio-records-permissions,
-        we will drop this constructor and replace SameAs with
-        invenio's SameAs.
-        """
-        super().__init__(*args, **kwargs)
-        if "policy" not in self.over:
-            self.over["policy"] = self
 
     can_commit_files = (FromRecordWorkflow("commit_files"),)
     can_create = (SystemProcess(), InAnyWorkflow("create"))

--- a/oarepo_workflows/services/permissions/workflow_permissions.py
+++ b/oarepo_workflows/services/permissions/workflow_permissions.py
@@ -18,11 +18,12 @@ from invenio_records_permissions.generators import (
     AnyUser,
     AuthenticatedUser,
     Disable,
+    SameAs,
     SystemProcess,
 )
 from invenio_users_resources.services.permissions import UserManager
 
-from .generators import IfInState, SameAs
+from .generators import IfInState
 
 
 class BaseWorkflowPermissionPolicy(RecordPermissionPolicy):
@@ -60,7 +61,6 @@ class DefaultWorkflowPermissions(BaseWorkflowPermissionPolicy):
             if self.system_process not in can:
                 can = (*can, self.system_process)
                 setattr(self.__class__, f"can_{action_name}", can)
-        over["policy"] = self
         super().__init__(action_name, **over)
 
     can_read = (

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -169,14 +169,14 @@ def test_hashable_list_can_wrap_need_objects():
 
 
 def test_require_all_raises_value_error_without_policy():
-    """needs() must raise ValueError when no policy key is present in context."""
+    """needs() must raise ValueError when no permission_policy key is present in context."""
     gen = RequireAll(FixedNeedsGenerator(UserNeed(1)))
     with pytest.raises(ValueError, match="Permission policy class is not set up in context"):
         gen.needs()
 
 
 def test_require_all_raises_value_error_with_other_context_keys():
-    """needs() must raise ValueError even when other keys are present but not 'policy'."""
+    """needs() must raise ValueError even when other keys are present but not 'permission_policy'."""
     gen = RequireAll(FixedNeedsGenerator(UserNeed(1)))
     with pytest.raises(ValueError, match="Permission policy class is not set up in context"):
         gen.needs(record={}, identity=None)
@@ -235,6 +235,7 @@ def test_require_all_needs_returns_single_composite_need():
 
     policy = MyPolicy("test")
     result = gen.needs(permission_policy=policy)
+    assert len(result) == 1
     assert result[0].method == "composite"
 
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 #
-"""Tests for CompositeAndGenerator and CompositePermissionPolicyMixin."""
+"""Tests for RequireAll and BooleanPermissionPolicyMixin."""
 
 from __future__ import annotations
 
@@ -17,9 +17,9 @@ from invenio_records_permissions import RecordPermissionPolicy
 from invenio_records_permissions.generators import Generator
 
 from oarepo_workflows.services.permissions.composite import (
-    CompositeAndGenerator,
-    CompositePermissionPolicyMixin,
+    BooleanPermissionPolicyMixin,
     HashableList,
+    RequireAll,
 )
 
 # ---------------------------------------------------------------------------
@@ -77,16 +77,13 @@ class EmptyGenerator(Generator):
 # ---------------------------------------------------------------------------
 
 
-class _CompositeTestPolicy(CompositePermissionPolicyMixin, RecordPermissionPolicy):
+class _CompositeTestPolicy(BooleanPermissionPolicyMixin, RecordPermissionPolicy):
     """Concrete policy for composite tests.
 
-    Injects ``policy=self`` into ``over`` so that ``CompositeAndGenerator``
-    can verify the policy type at needs-collection time.
+    Invenio's ``BasePermissionPolicy.__init__`` automatically injects
+    ``permission_policy=self`` into ``over``, which ``RequireAll`` uses to
+    verify the policy type at needs-collection time.
     """
-
-    def __init__(self, action, **over: Any):
-        super().__init__(action, **over)
-        self.over["policy"] = self
 
 
 # ---------------------------------------------------------------------------
@@ -167,142 +164,139 @@ def test_hashable_list_can_wrap_need_objects():
 
 
 # ===========================================================================
-# CompositeAndGenerator - error paths (no Flask context required)
+# RequireAll - error paths (no Flask context required)
 # ===========================================================================
 
 
-def test_composite_and_generator_raises_value_error_without_policy():
+def test_require_all_raises_value_error_without_policy():
     """needs() must raise ValueError when no policy key is present in context."""
-    gen = CompositeAndGenerator(FixedNeedsGenerator(UserNeed(1)))
+    gen = RequireAll(FixedNeedsGenerator(UserNeed(1)))
     with pytest.raises(ValueError, match="Permission policy class is not set up in context"):
         gen.needs()
 
 
-def test_composite_and_generator_raises_value_error_with_other_context_keys():
+def test_require_all_raises_value_error_with_other_context_keys():
     """needs() must raise ValueError even when other keys are present but not 'policy'."""
-    gen = CompositeAndGenerator(FixedNeedsGenerator(UserNeed(1)))
+    gen = RequireAll(FixedNeedsGenerator(UserNeed(1)))
     with pytest.raises(ValueError, match="Permission policy class is not set up in context"):
         gen.needs(record={}, identity=None)
 
 
-def test_composite_and_generator_raises_type_error_for_plain_policy():
+def test_require_all_raises_type_error_for_plain_policy():
     """needs() must raise TypeError when policy is a plain RecordPermissionPolicy."""
-    gen = CompositeAndGenerator(FixedNeedsGenerator(UserNeed(1)))
+    gen = RequireAll(FixedNeedsGenerator(UserNeed(1)))
     wrong_policy = RecordPermissionPolicy("read")
     with pytest.raises(
         TypeError,
-        match="Permission policy class is not a CompositePermissionPolicyMixin",
+        match="Permission policy class is not a BooleanPermissionPolicyMixin",
     ):
-        gen.needs(policy=wrong_policy)
+        gen.needs(permission_policy=wrong_policy)
 
 
 # ===========================================================================
-# CompositeAndGenerator - repr / str (no Flask context required)
+# RequireAll - repr / str (no Flask context required)
 # ===========================================================================
 
 
-def test_composite_and_generator_repr_single_inner_generator():
+def test_require_all_repr_single_inner_generator():
     g = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g)
-    expected = f"CompositeAndGenerator({g!r})"
+    gen = RequireAll(g)
+    expected = f"RequireAll({g!r})"
     assert repr(gen) == expected
 
 
-def test_composite_and_generator_str_equals_repr():
+def test_require_all_str_equals_repr():
     g = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g)
+    gen = RequireAll(g)
     assert str(gen) == repr(gen)
 
 
-def test_composite_and_generator_repr_multiple_inner_generators():
+def test_require_all_repr_multiple_inner_generators():
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(UserNeed(2))
-    gen = CompositeAndGenerator(g1, g2)
-    expected = f"CompositeAndGenerator({g1!r}, {g2!r})"
+    gen = RequireAll(g1, g2)
+    expected = f"RequireAll({g1!r}, {g2!r})"
     assert repr(gen) == expected
 
 
 # ===========================================================================
-# CompositeAndGenerator - needs() with valid policy (no Flask context needed
+# RequireAll - needs() with valid policy (no Flask context needed
 # because we only call gen.needs() directly, not policy.needs)
 # ===========================================================================
 
 
-def test_composite_and_generator_needs_returns_single_composite_need():
+def test_require_all_needs_returns_single_composite_need():
     """needs() must return exactly one Need with method='composite'."""
     g1 = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g1)
+    gen = RequireAll(g1)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
 
     policy = MyPolicy("test")
-    result = gen.needs(policy=policy)
-
-    assert len(result) == 1
+    result = gen.needs(permission_policy=policy)
     assert result[0].method == "composite"
 
 
-def test_composite_and_generator_needs_value_is_hashable_list():
+def test_require_all_needs_value_is_hashable_list():
     """The value of the composite Need must be a HashableList."""
     g1 = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g1)
+    gen = RequireAll(g1)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
 
     policy = MyPolicy("test")
-    need = gen.needs(policy=policy)[0]
+    need = gen.needs(permission_policy=policy)[0]
     assert isinstance(need.value, HashableList)
 
 
-def test_composite_and_generator_needs_value_contains_inner_generators():
+def test_require_all_needs_value_contains_inner_generators():
     """The HashableList in the composite Need must contain the inner generators."""
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(UserNeed(2))
-    gen = CompositeAndGenerator(g1, g2)
+    gen = RequireAll(g1, g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
 
     policy = MyPolicy("test")
-    need = gen.needs(policy=policy)[0]
+    need = gen.needs(permission_policy=policy)[0]
     assert list(need.value) == [g1, g2]
 
 
-def test_composite_and_generator_composite_need_is_hashable():
+def test_require_all_composite_need_is_hashable():
     """The returned Need must be hashable (required for use in frozensets)."""
     g1 = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g1)
+    gen = RequireAll(g1)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
 
     policy = MyPolicy("test")
-    need = gen.needs(policy=policy)[0]
-    # Must not raise
+    need = gen.needs(permission_policy=policy)[0]
     assert isinstance(hash(need), int)
     assert need in frozenset([need])  # noqa FURB171
 
 
-def test_composite_and_generator_each_call_creates_new_hashable_list():
+def test_require_all_each_call_creates_new_hashable_list():
     """Two calls to needs() must return distinct HashableLists (different objects)."""
     g1 = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g1)
+    gen = RequireAll(g1)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
 
     policy = MyPolicy("test")
-    hl1 = gen.needs(policy=policy)[0].value
-    hl2 = gen.needs(policy=policy)[0].value
+    hl1 = gen.needs(permission_policy=policy)[0].value
+    hl2 = gen.needs(permission_policy=policy)[0].value
     # Different objects even though contents are the same
     assert hl1 is not hl2
     assert hl1 != hl2
 
 
 # ===========================================================================
-# CompositePermissionPolicyMixin.allows() - requires Flask + DB
+# BooleanPermissionPolicyMixin.allows() - requires Flask + DB
 # ===========================================================================
 
 
@@ -331,7 +325,7 @@ def test_composite_mixin_denies_when_regular_needs_do_not_match(app, db):
 def test_composite_mixin_allows_single_inner_generator_matching(app, db):
     """Composite with one inner generator: identity satisfying that need is allowed."""
     g = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g)
+    gen = RequireAll(g)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -343,7 +337,7 @@ def test_composite_mixin_allows_single_inner_generator_matching(app, db):
 def test_composite_mixin_denies_single_inner_generator_not_matching(app, db):
     """Composite with one inner generator: identity without the need is denied."""
     g = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g)
+    gen = RequireAll(g)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -357,7 +351,7 @@ def test_composite_mixin_and_logic_allows_when_all_inner_generators_match(app, d
     role_need = Need("role", "editor")
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(role_need)
-    gen = CompositeAndGenerator(g1, g2)
+    gen = RequireAll(g1, g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -371,7 +365,7 @@ def test_composite_mixin_and_logic_denies_when_first_inner_generator_does_not_ma
     role_need = Need("role", "editor")
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(role_need)
-    gen = CompositeAndGenerator(g1, g2)
+    gen = RequireAll(g1, g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -386,7 +380,7 @@ def test_composite_mixin_and_logic_denies_when_second_inner_generator_does_not_m
     role_need = Need("role", "editor")
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(role_need)
-    gen = CompositeAndGenerator(g1, g2)
+    gen = RequireAll(g1, g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -403,7 +397,7 @@ def test_composite_mixin_and_logic_three_inner_generators_all_match(app, db):
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(role_a)
     g3 = FixedNeedsGenerator(role_b)
-    gen = CompositeAndGenerator(g1, g2, g3)
+    gen = RequireAll(g1, g2, g3)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -422,7 +416,7 @@ def test_composite_mixin_excludes_deny_even_when_needs_match(app, db):
     """An excluded identity is denied even if its needs match the composite."""
     ban = Need("role", "banned")
     g = FixedExcludesGenerator(needs=[UserNeed(1)], excludes=[ban])
-    gen = CompositeAndGenerator(g)
+    gen = RequireAll(g)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -436,7 +430,7 @@ def test_composite_mixin_allows_when_excluded_need_not_present(app, db):
     """Exclude need not present in identity does not prevent access."""
     ban = Need("role", "banned")
     g = FixedExcludesGenerator(needs=[UserNeed(1)], excludes=[ban])
-    gen = CompositeAndGenerator(g)
+    gen = RequireAll(g)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -451,7 +445,7 @@ def test_composite_mixin_excludes_in_second_inner_generator_deny(app, db):
     ban = Need("role", "banned")
     g1 = FixedNeedsGenerator(UserNeed(1))  # only needs
     g2 = FixedExcludesGenerator(needs=[Need("role", "editor")], excludes=[ban])
-    gen = CompositeAndGenerator(g1, g2)
+    gen = RequireAll(g1, g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -471,7 +465,7 @@ def test_composite_mixin_empty_inner_generator_prevents_satisfaction(app, db):
     """
     g_empty = EmptyGenerator()
     g_normal = FixedNeedsGenerator(UserNeed(1))
-    gen = CompositeAndGenerator(g_empty, g_normal)
+    gen = RequireAll(g_empty, g_normal)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -481,11 +475,11 @@ def test_composite_mixin_empty_inner_generator_prevents_satisfaction(app, db):
 
 
 def test_composite_mixin_or_semantics_first_composite_matches(app, db):
-    """Multiple CompositeAndGenerators behave with OR semantics: first match wins."""
+    """Multiple RequireAll generators behave with OR semantics: first match wins."""
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(UserNeed(2))
-    gen1 = CompositeAndGenerator(g1)
-    gen2 = CompositeAndGenerator(g2)
+    gen1 = RequireAll(g1)
+    gen2 = RequireAll(g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen1, gen2)
@@ -495,11 +489,11 @@ def test_composite_mixin_or_semantics_first_composite_matches(app, db):
 
 
 def test_composite_mixin_or_semantics_second_composite_matches(app, db):
-    """Multiple CompositeAndGenerators: second one satisfying the identity is enough."""
+    """Multiple RequireAll generators: second one satisfying the identity is enough."""
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(UserNeed(2))
-    gen1 = CompositeAndGenerator(g1)
-    gen2 = CompositeAndGenerator(g2)
+    gen1 = RequireAll(g1)
+    gen2 = RequireAll(g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen1, gen2)
@@ -509,11 +503,11 @@ def test_composite_mixin_or_semantics_second_composite_matches(app, db):
 
 
 def test_composite_mixin_or_semantics_neither_composite_matches(app, db):
-    """Multiple CompositeAndGenerators: identity satisfying none of them is denied."""
+    """Multiple RequireAll generators: identity satisfying none of them is denied."""
     g1 = FixedNeedsGenerator(UserNeed(1))
     g2 = FixedNeedsGenerator(UserNeed(2))
-    gen1 = CompositeAndGenerator(g1)
-    gen2 = CompositeAndGenerator(g2)
+    gen1 = RequireAll(g1)
+    gen2 = RequireAll(g2)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen1, gen2)
@@ -530,7 +524,7 @@ def test_composite_mixin_mixed_regular_and_composite_generators(app, db):
     """
     regular_gen = FixedNeedsGenerator(UserNeed(10))
     composite_inner = FixedNeedsGenerator(UserNeed(20))
-    composite_gen = CompositeAndGenerator(composite_inner)
+    composite_gen = RequireAll(composite_inner)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (regular_gen, composite_gen)
@@ -550,7 +544,7 @@ def test_composite_mixin_and_logic_combining_user_and_role_needs(app, db):
     admin_role = Need("role", "admin")
     g_user = FixedNeedsGenerator(UserNeed(42))
     g_role = FixedNeedsGenerator(admin_role)
-    gen = CompositeAndGenerator(g_user, g_role)
+    gen = RequireAll(g_user, g_role)
 
     class MyPolicy(_CompositeTestPolicy):
         can_test = (gen,)
@@ -569,7 +563,7 @@ def test_composite_mixin_and_logic_combining_user_and_role_needs(app, db):
 
 
 def test_composite_mixin_no_composite_generators_falls_back_to_super(app, db):
-    """Without any CompositeAndGenerator the mixin delegates entirely to super."""
+    """Without any RequireAll generator the mixin delegates entirely to super."""
     g = FixedNeedsGenerator(UserNeed(5))
 
     class MyPolicy(_CompositeTestPolicy):


### PR DESCRIPTION
## Rename composite permission generators and align with Invenio internals

### Summary

Improves the naming of the boolean permission composition API and removes
workarounds that are no longer needed now that Invenio injects
`permission_policy` into the generator context natively.

---

### Changes

#### Renames
- `CompositeAndGenerator` → `RequireAll`
  Reads naturally at the call site: `RequireAll(RecordOwners(), ReviewerRole())`
  leaves no doubt that *all* conditions must be satisfied.
- `CompositePermissionPolicyMixin` → `BooleanPermissionPolicyMixin`
  Signals that the mixin enables boolean/logical generator evaluation, and is
  forward-compatible with future operators (e.g. `NotAll`).

#### Invenio `permission_policy` context alignment

Invenio's `BasePermissionPolicy.__init__` now injects `permission_policy=self`
into the generator context automatically. The project previously worked around
this by injecting a separate `policy` key in several places. These workarounds
are now removed:

- `RequireAll.needs()` looks up `"permission_policy"` instead of `"policy"`
- Removed manual `over["policy"] = self` from `DefaultWorkflowPermissions.__init__`
- Removed the entire `WorkflowRecordPermissionPolicyMixin.__init__` (its sole
  purpose was injecting `"policy"`)

#### `SameAs` deprecation

Invenio now ships its own `SameAs` generator. The local subclass is deprecated
with a `DeprecationWarning` pointing users to
`invenio_records_permissions.generators.SameAs`. All internal usages within the
package have been migrated to the Invenio version directly.

---

### Migration guide for downstream users

| Before | After |
|---|---|
| `from oarepo_workflows.services.permissions.composite import CompositeAndGenerator` | `from oarepo_workflows.services.permissions.composite import RequireAll` |
| `from oarepo_workflows.services.permissions.composite import CompositePermissionPolicyMixin` | `from oarepo_workflows.services.permissions.composite import BooleanPermissionPolicyMixin` |
| `from oarepo_workflows.services.permissions.generators import SameAs` | `from invenio_records_permissions.generators import SameAs` |
| Manual `self.over["policy"] = self` in custom policy `__init__` | Not needed — Invenio injects `permission_policy` automatically |
