### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oarepo-workflows"
-version = "6.1.0"
+version = "7.0.0"
 description = "OARepo module allowing record workflow functionality"
 readme = "README.md"
 authors = [
@@ -10,11 +10,11 @@ requires-python = ">=3.14,<3.15"
 
 dependencies = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
-    "oarepo-model>=4.0.0,<5.0.0",
-    "oarepo-runtime>=6.0.0,<7.0.0",
+    "oarepo-model>=5.0.0,<6.0.0",
+    "oarepo-runtime>=7.0.0,<8.0.0",
 
     # invenio
-    "invenio-rdm-records>=31.0.0,<32.0.0",
+    "invenio-rdm-records>=32.0.1,<33.0.0",
     "invenio-search>=3.1.2,<4.0.0",
 ]
 
@@ -29,7 +29,7 @@ dev = [
 ]
 
 tests = [
-    "oarepo-rdm>=7.0.0,<8.0.0",
+    "oarepo-rdm>=8.0.0,<9.0.0",
 
     # invenio dependencies
     "pytest-invenio>=4.0.0,<5.0.0",


### PR DESCRIPTION
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-runtime, oarepo-model, oarepo-rdm.
